### PR TITLE
feat: pseudo node ip

### DIFF
--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -3,10 +3,12 @@ package utils
 import (
 	"context"
 	"fmt"
-	errpkg "github.com/pkg/errors"
 	"os"
+	"reflect"
 	"strings"
 	"time"
+
+	errpkg "github.com/pkg/errors"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/koupleless/virtual-kubelet/model"
@@ -427,4 +429,12 @@ func ConvertNodeToNodeInfo(node *corev1.Node) model.NodeInfo {
 		CustomTaints:      node.Spec.Taints,
 		State:             model.NodeStateActivated,
 	}
+}
+
+// OrElse returns the value if it is not nil or zero, otherwise returns the default value.
+func OrElse[T any](value T, defaultValue T) T {
+	if reflect.ValueOf(value).IsZero() {
+		return defaultValue
+	}
+	return value
 }

--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -3,14 +3,15 @@ package utils
 import (
 	"context"
 	"errors"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/koupleless/virtual-kubelet/model"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestTimedTaskWithInterval(t *testing.T) {
@@ -343,4 +344,12 @@ func TestFillPodKey(t *testing.T) {
 	assert.Equal(t, "ut-ns/ut-pod1", bizStatusDatasWithPodKey[0].PodKey)
 	assert.Equal(t, "ut-ns/ut-pod2", bizStatusDatasWithPodKey[1].PodKey)
 	assert.Equal(t, len(bizStatusDatasWithNoPodKey), 0)
+}
+
+func TestOrElse(t *testing.T) {
+	assert.Equal(t, "default", OrElse("", "default"))
+	assert.EqualValues(t, 1, OrElse(0, 1))
+	assert.EqualValues(t, 1.0, OrElse(0, 1.0))
+	assert.EqualValues(t, ptr.To(1), OrElse(nil, ptr.To(1)))
+	assert.Equal(t, "value", OrElse("value", "default"))
 }

--- a/model/consts.go
+++ b/model/consts.go
@@ -45,6 +45,10 @@ const (
 	LabelKeyOfBaseVersion = "base.koupleless.io/version"
 	// LabelKeyOfBaseClusterName is the constant string used as a key for base cluster name.
 	LabelKeyOfBaseClusterName = "base.koupleless.io/cluster-name"
+	// LabelKeyOfBaseHostName is a constant string used as a key for base host name.
+	LabelKeyOfBaseHostName = "base.koupleless.io/host-name"
+	// LabelKeyOfBaseContainerName is a constant string used as a key for base container name.
+	LabelKeyOfBaseContainerName = "base.koupleless.io/container-name"
 )
 
 const (

--- a/model/models.go
+++ b/model/models.go
@@ -59,8 +59,9 @@ type BizStatusData struct {
 type BuildVNodeConfig struct {
 	Client            client.Client     // Runtime client instance
 	KubeCache         cache.Cache       // Cache of kube resources
-	NodeIP            string            // IP of the node
-	NodeHostname      string            // Hostname of the node
+	BaseIP            string            // IP of the base
+	BaseHostName      string            // Hostname of the base
+	NodeIP            string            // NodeIP of the node
 	NodeName          string            // NodeName of the node
 	NodeVersion       string            // NodeVersion of the node
 	BaseName          string            // BaseName of the base, which is the app name of base
@@ -82,6 +83,7 @@ type BuildVNodeControllerConfig struct {
 	IsCluster        bool          // Whether the deployment is in a cluster
 	WorkloadMaxLevel int           // Maximum workload level
 	VNodeWorkerNum   int           // VNode container event processor worker num, default 1, means execute Container events serially
+	PseudoNodeIP     string        // Pseudo node IP, will be used as the node IP for vnodes.
 }
 
 // QueryBaselineRequest is the request parameters of query baseline func

--- a/provider/vnode_store_test.go
+++ b/provider/vnode_store_test.go
@@ -1,10 +1,11 @@
 package provider
 
 import (
-	"github.com/koupleless/virtual-kubelet/model"
-	"gotest.tools/assert"
 	"testing"
 	"time"
+
+	"github.com/koupleless/virtual-kubelet/model"
+	"gotest.tools/assert"
 )
 
 func TestNewVNodeStore(t *testing.T) {
@@ -71,7 +72,8 @@ func TestGetLeaseOutdatedVNodeName(t *testing.T) {
 	}
 
 	vNode.lease = vNode.NewLease(clientId)
-	vNode.lease.Spec.RenewTime.Time = time.Now().Add(-time.Second * model.NodeLeaseDurationSeconds)
+	// @fix: make sure the lease is outdated
+	vNode.lease.Spec.RenewTime.Time = time.Now().Add(-2 * time.Second * model.NodeLeaseDurationSeconds)
 	store.AddVNode(nodeName, vNode)
 	nameList := store.GetLeaseOutdatedVNodeNames(clientId)
 	assert.Assert(t, len(nameList) == 1)


### PR DESCRIPTION
使用指定的 node ip 替代 tunnel 基座发现传回的 ip，用于 ``kubectl logs`` 的流量劫持。 
相关 issue: https://github.com/koupleless/koupleless/issues/412

provider/vnode_store_test.go 中的修改是发现本地环境测试不通过，因而增大了时间差；
vnode_controller/vnode_controller_test.go 中的修改是进行了一下优化，减少测试等待时间。

新引入的 PseudoNodeIP 如果不指定，就会回退到之前的逻辑，因此可以平滑升级。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a generic utility function to provide default values when a given value is zero or nil.
  * Added new Kubernetes label keys for base host name and base container name.
  * Added support for configuring and using a pseudo node IP address in virtual node controllers.

* **Bug Fixes**
  * Improved test reliability by replacing fixed delays with event-based assertions.

* **Refactor**
  * Renamed and reorganized configuration fields for clarity and consistency in virtual node setup.
  * Updated label and address handling for nodes to use new configuration fields.

* **Tests**
  * Added tests for the new utility function.
  * Enhanced vnode controller tests for more robust validation of leadership behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->