### PR TITLE
fix: biz module upgrade issue

### DIFF
--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -168,6 +168,22 @@ func TestConvertBizStatusToContainerStatus_NoData(t *testing.T) {
 	assert.Equal(t, status.State, corev1.ContainerState{})
 }
 
+func TestConvertBizStatusToContainerStatus_UnResolved(t *testing.T) {
+	status, _ := ConvertBizStatusToContainerStatus(&corev1.Container{
+		Name:  "suite",
+		Image: "test_img",
+	}, &corev1.ContainerStatus{Name: "suite"}, &model.BizStatusData{
+		Key:        "test_key",
+		Name:       "suite",
+		PodKey:     "pod_key",
+		State:      string(model.BizStateUnResolved),
+		ChangeTime: time.Now(),
+		Reason:     "resolved",
+		Message:    "resolved message",
+	})
+	assert.Equal(t, status.State.Waiting.Reason, model.StateReasonAwaitingResync)
+}
+
 func TestConvertBizStatusToContainerStatus_RESOLVED(t *testing.T) {
 	status, _ := ConvertBizStatusToContainerStatus(&corev1.Container{
 		Name:  "suite",

--- a/model/consts.go
+++ b/model/consts.go
@@ -127,3 +127,8 @@ const (
 	// NodeToCheckUnreachableAndDeadStatusInterval is the interval to check if node status is unreachable or dead
 	NodeToCheckUnreachableAndDeadStatusInterval = 3
 )
+
+const (
+	// StateReasonAwaitingResync is a constant string used to indicate that a resource is awaiting resynchronization.
+	StateReasonAwaitingResync = "AwaitingResync"
+)

--- a/virtual_kubelet/node/podcontroller.go
+++ b/virtual_kubelet/node/podcontroller.go
@@ -17,14 +17,15 @@ package node
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/koupleless/virtual-kubelet/common/utils"
 	"github.com/koupleless/virtual-kubelet/model"
 	"github.com/koupleless/virtual-kubelet/virtual_kubelet/internal/queue"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sync"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	pkgerrors "github.com/pkg/errors"


### PR DESCRIPTION
修复 https://github.com/koupleless/koupleless/issues/405 中提到的 deployment 滚动升级遇到的错误。

问题复现：

biz 模块使用 deployment 部署，当触发 deployment 的副本更新后，module-controller 侧的时序是这样的：
<img width="1075" height="183" alt="a76a07b3f42f2b13246a90cb825a3b17" src="https://github.com/user-attachments/assets/a5b2241b-83eb-40ac-9d0b-7295d3b5c771" />
后续新的 pod 一直会卡在 pending 状态，module-controller 会重复输出类似如下日志：
<img width="2065" height="344" alt="130658fa4c701420926dfcdfa4bf4b21" src="https://github.com/user-attachments/assets/8f821753-73f8-40b3-a945-f6975886164a" />
K8s 的 deployment 的 RollingUpdate strategy 过程可以近似看作：
start -> repeat(扩增新副本集 -> 新 pod ready -> 收缩旧副本集) -> end
因为基座没有 revision 能力，导致新旧两个版本的 vpod 的 container 操作同一个基座中的模块，造成先 install 后 uninstall，最终 biz 模块在对应基座的 JVM 中消失。

Patch 思路：

module-controller 通过 tunnel 同步 biz module -> k8s container 状态时，如果发现 vpod 的 container 存在且对应的 biz module 状态为 **UNRESOLVED** 时，通过 ``ContainerStatus`` 为该容器增加一个 ``Waiting`` 状态，``Reason`` 标记为 **AwaitingResync**，在后续的事件循环中，可以通过这个状态过滤出需要重新发送 Install 指令的容器，最后统一再次 install