### PR TITLE
fix 模块 pod 替换导致 JVM 进程内模块实例消失

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/model/consts.go
+++ b/model/consts.go
@@ -123,3 +123,7 @@ const (
 	// NodeToCheckUnreachableAndDeadStatusInterval is the interval to check if node status is unreachable or dead
 	NodeToCheckUnreachableAndDeadStatusInterval = 3
 )
+
+const (
+	ObjectMetaNameNotExistPod = "not-exist-pod"
+)

--- a/provider/vnode.go
+++ b/provider/vnode.go
@@ -263,7 +263,7 @@ func (vNode *VNode) syncNotExistBizPodToProvider(ctx context.Context, toDeleteIn
 		bizName, bizVersion := utils.GetBizNameAndVersionFromUniqueKey(bizStatus.Key)
 		err := vNode.podProvider.DeletePod(ctx, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "not-exist-pod",
+				Name:      model.ObjectMetaNameNotExistPod,
 				Namespace: corev1.NamespaceDefault,
 			},
 			Spec: corev1.PodSpec{

--- a/provider/vnode_test.go
+++ b/provider/vnode_test.go
@@ -1,7 +1,17 @@
 package provider
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"github.com/koupleless/virtual-kubelet/common/tracker"
+	"github.com/koupleless/virtual-kubelet/model"
+	"github.com/koupleless/virtual-kubelet/tunnel"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestVNode_ExitWhenLeaderChanged(t *testing.T) {
@@ -19,4 +29,306 @@ func TestVNode_ExitWhenLeaderChanged(t *testing.T) {
 	//default:
 	//	assert.Fail(t, "ExitWhenLeaderChanged should not called")
 	//}
+}
+
+func setupTest() {
+	// Initialize tracker to avoid nil pointer issues
+	defaultTracker := &tracker.DefaultTracker{}
+	defaultTracker.Init()
+	tracker.SetTracker(defaultTracker)
+}
+
+func TestVNode_SyncOneNodeBizStatusToKube(t *testing.T) {
+	setupTest()
+
+	tests := []struct {
+		name               string
+		toUpdateInKube     []model.BizStatusData
+		toDeleteInProvider []model.BizStatusData
+		podProviderNil     bool
+	}{
+		{
+			name: "successful sync with updates and deletes",
+			toUpdateInKube: []model.BizStatusData{
+				{
+					Key:        "biz1:1.0.0",
+					Name:       "biz1",
+					PodKey:     "test-pod-1",
+					State:      "ACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Started",
+					Message:    "Biz started successfully",
+				},
+				{
+					Key:        "biz2:2.0.0",
+					Name:       "biz2",
+					PodKey:     "test-pod-2",
+					State:      "ACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Started",
+					Message:    "Biz started successfully",
+				},
+			},
+			toDeleteInProvider: []model.BizStatusData{
+				{
+					Key:        "biz3:1.0.0",
+					Name:       "biz3",
+					PodKey:     "test-pod-3",
+					State:      "DEACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Stopped",
+					Message:    "Biz stopped",
+				},
+			},
+			podProviderNil: false,
+		},
+		{
+			name:               "empty arrays",
+			toUpdateInKube:     []model.BizStatusData{},
+			toDeleteInProvider: []model.BizStatusData{},
+			podProviderNil:     false,
+		},
+		{
+			name: "only updates",
+			toUpdateInKube: []model.BizStatusData{
+				{
+					Key:        "biz1:1.0.0",
+					Name:       "biz1",
+					PodKey:     "test-pod-1",
+					State:      "ACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Started",
+					Message:    "Biz started successfully",
+				},
+			},
+			toDeleteInProvider: []model.BizStatusData{},
+			podProviderNil:     false,
+		},
+		{
+			name:           "only deletes",
+			toUpdateInKube: []model.BizStatusData{},
+			toDeleteInProvider: []model.BizStatusData{
+				{
+					Key:        "biz3:1.0.0",
+					Name:       "biz3",
+					PodKey:     "test-pod-3",
+					State:      "DEACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Stopped",
+					Message:    "Biz stopped",
+				},
+			},
+			podProviderNil: false,
+		},
+		{
+			name: "pod provider is nil",
+			toUpdateInKube: []model.BizStatusData{
+				{
+					Key:        "biz1:1.0.0",
+					Name:       "biz1",
+					PodKey:     "test-pod-1",
+					State:      "ACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Started",
+					Message:    "Biz started successfully",
+				},
+			},
+			toDeleteInProvider: []model.BizStatusData{
+				{
+					Key:        "biz3:1.0.0",
+					Name:       "biz3",
+					PodKey:     "test-pod-3",
+					State:      "DEACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Stopped",
+					Message:    "Biz stopped",
+				},
+			},
+			podProviderNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create VNode instance
+			vNode := &VNode{
+				name:      "test-node",
+				env:       "test",
+				client:    fake.NewClientBuilder().Build(),
+				kubeCache: &informertest.FakeInformers{},
+			}
+
+			if !tt.podProviderNil {
+				// Create a real VPodProvider with mock tunnel
+				mockTunnel := &tunnel.MockTunnel{}
+				vNode.podProvider = NewVPodProvider("default", "127.0.0.1", "test-node",
+					fake.NewClientBuilder().Build(), &informertest.FakeInformers{}, mockTunnel)
+
+				// Set up a dummy notify callback to avoid nil pointer reference
+				vNode.podProvider.NotifyPods(context.Background(), func(pod *corev1.Pod) {
+					// This is a dummy callback for testing
+				})
+			}
+
+			// Execute the method - this should not panic and should complete without error
+			ctx := context.Background()
+
+			// Call the method under test
+			vNode.SyncOneNodeBizStatusToKube(ctx, tt.toUpdateInKube, tt.toDeleteInProvider)
+
+			// For this test, we mainly verify that:
+			// 1. The method doesn't panic
+			// 2. The method handles nil podProvider gracefully
+			// 3. The method processes all input data without error
+
+			// If we reach this point, the test passed
+			assert.True(t, true, "SyncOneNodeBizStatusToKube completed without panic")
+		})
+	}
+}
+
+func TestVNode_SyncOneNodeBizStatusToKube_NilPodProvider(t *testing.T) {
+	setupTest()
+
+	// Test specifically for nil podProvider behavior
+	vNode := &VNode{
+		name:        "test-node",
+		env:         "test",
+		client:      fake.NewClientBuilder().Build(),
+		kubeCache:   &informertest.FakeInformers{},
+		podProvider: nil, // Explicitly set to nil
+	}
+
+	toUpdateInKube := []model.BizStatusData{
+		{
+			Key:        "biz1:1.0.0",
+			Name:       "biz1",
+			PodKey:     "test-pod-1",
+			State:      "ACTIVATED",
+			ChangeTime: time.Now(),
+			Reason:     "Started",
+			Message:    "Biz started successfully",
+		},
+	}
+
+	toDeleteInProvider := []model.BizStatusData{
+		{
+			Key:        "biz3:1.0.0",
+			Name:       "biz3",
+			PodKey:     "test-pod-3",
+			State:      "DEACTIVATED",
+			ChangeTime: time.Now(),
+			Reason:     "Stopped",
+			Message:    "Biz stopped",
+		},
+	}
+
+	ctx := context.Background()
+
+	// This should not panic when podProvider is nil
+	assert.NotPanics(t, func() {
+		vNode.SyncOneNodeBizStatusToKube(ctx, toUpdateInKube, toDeleteInProvider)
+	}, "SyncOneNodeBizStatusToKube should handle nil podProvider gracefully")
+}
+
+func TestVNode_SyncOneNodeBizStatusToKube_EmptyInputs(t *testing.T) {
+	setupTest()
+
+	// Test with empty input arrays
+	mockTunnel := &tunnel.MockTunnel{}
+	vNode := &VNode{
+		name:      "test-node",
+		env:       "test",
+		client:    fake.NewClientBuilder().Build(),
+		kubeCache: &informertest.FakeInformers{},
+		podProvider: NewVPodProvider("default", "127.0.0.1", "test-node",
+			fake.NewClientBuilder().Build(), &informertest.FakeInformers{}, mockTunnel),
+	}
+
+	// Set up a dummy notify callback to avoid nil pointer reference
+	vNode.podProvider.NotifyPods(context.Background(), func(pod *corev1.Pod) {
+		// This is a dummy callback for testing
+	})
+
+	ctx := context.Background()
+
+	// Test with empty arrays
+	assert.NotPanics(t, func() {
+		vNode.SyncOneNodeBizStatusToKube(ctx, []model.BizStatusData{}, []model.BizStatusData{})
+	}, "SyncOneNodeBizStatusToKube should handle empty arrays gracefully")
+}
+
+func TestVNode_SyncOneNodeBizStatusToKube_BizKeyParsing(t *testing.T) {
+	setupTest()
+
+	// Test the syncNotExistBizPodToProvider method behavior with different biz keys
+	tests := []struct {
+		name            string
+		bizKey          string
+		expectedName    string
+		expectedVersion string
+	}{
+		{
+			name:            "valid biz key with colon separator",
+			bizKey:          "test-biz:1.0.0",
+			expectedName:    "test-biz",
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:            "biz key without version",
+			bizKey:          "test-biz",
+			expectedName:    "",
+			expectedVersion: "",
+		},
+		{
+			name:            "biz key with multiple colons",
+			bizKey:          "test:biz:1.0.0",
+			expectedName:    "test",
+			expectedVersion: "biz:1.0.0",
+		},
+		{
+			name:            "empty biz key",
+			bizKey:          "",
+			expectedName:    "",
+			expectedVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTunnel := &tunnel.MockTunnel{}
+			vNode := &VNode{
+				name:      "test-node",
+				env:       "test",
+				client:    fake.NewClientBuilder().Build(),
+				kubeCache: &informertest.FakeInformers{},
+				podProvider: NewVPodProvider("default", "127.0.0.1", "test-node",
+					fake.NewClientBuilder().Build(), &informertest.FakeInformers{}, mockTunnel),
+			}
+
+			// Set up a dummy notify callback to avoid nil pointer reference
+			vNode.podProvider.NotifyPods(context.Background(), func(pod *corev1.Pod) {
+				// This is a dummy callback for testing
+			})
+
+			toDeleteInProvider := []model.BizStatusData{
+				{
+					Key:        tt.bizKey,
+					Name:       "test-biz",
+					PodKey:     "test-pod",
+					State:      "DEACTIVATED",
+					ChangeTime: time.Now(),
+					Reason:     "Stopped",
+					Message:    "Biz stopped",
+				},
+			}
+
+			ctx := context.Background()
+
+			// Test that the method doesn't panic with different biz key formats
+			assert.NotPanics(t, func() {
+				vNode.SyncOneNodeBizStatusToKube(ctx, []model.BizStatusData{}, toDeleteInProvider)
+			}, "SyncOneNodeBizStatusToKube should handle different biz key formats without panic")
+		})
+	}
 }

--- a/provider/vpod_provider.go
+++ b/provider/vpod_provider.go
@@ -220,7 +220,13 @@ func (b *VPodProvider) handleBizBatchStop(ctx context.Context, pod *corev1.Pod, 
 	for _, container := range containers {
 		err := tracker.G().FuncTrack(labelMap[model.LabelKeyOfTraceID], model.TrackSceneVPodDeploy, model.TrackEventContainerShutdown, labelMap, func() (error, model.ErrorCode) {
 			err := utils.CallWithRetry(ctx, func(_ int) (bool, error) {
-				innerErr := b.tunnel.StopBiz(b.nodeName, podKey, &container)
+				var podKeyToStopBiz string
+				if strings.HasSuffix(podKey, model.ObjectMetaNameNotExistPod) {
+					podKeyToStopBiz = ""
+				} else {
+					podKeyToStopBiz = podKey
+				}
+				innerErr := b.tunnel.StopBiz(b.nodeName, podKeyToStopBiz, &container)
 
 				return innerErr != nil, innerErr
 			}, nil)

--- a/provider/vpod_provider.go
+++ b/provider/vpod_provider.go
@@ -16,15 +16,16 @@ package provider
 
 import (
 	"context"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/koupleless/virtual-kubelet/tunnel"
 	"github.com/koupleless/virtual-kubelet/virtual_kubelet/node"
 	"github.com/koupleless/virtual-kubelet/virtual_kubelet/node/nodeutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sort"
-	"strings"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/koupleless/virtual-kubelet/common/tracker"
@@ -337,7 +338,7 @@ func (b *VPodProvider) UpdatePod(ctx context.Context, pod *corev1.Pod) error {
 		}
 		return true, nil
 	}, time.Minute, time.Second, func() {
-		b.handleBizBatchStart(ctx, newPod, shouldStopContainers)
+		b.handleBizBatchStart(ctx, newPod, shouldStartContainers)
 	}, func() {
 		logger.Error("stop old containers timeout, not start new containers")
 	})


### PR DESCRIPTION
https://github.com/koupleless/koupleless/issues/405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected post-update behavior so the intended containers are started after updates.
  - Improved handling of special-case/non-existent pods during deletion and batch stop to reduce errors and invalid identifiers.
- Tests
  - Expanded unit test coverage for node/pod sync and deletion scenarios, including nil-provider and empty-input cases.
- Chores
  - Standardized internal naming for special-case pods and cleaned up import organization; dependency graph updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->